### PR TITLE
CompositionEngine: Request device composition for the Udfps touched layer

### DIFF
--- a/services/surfaceflinger/CompositionEngine/src/Output.cpp
+++ b/services/surfaceflinger/CompositionEngine/src/Output.cpp
@@ -22,6 +22,7 @@
 #include <compositionengine/LayerFE.h>
 #include <compositionengine/LayerFECompositionState.h>
 #include <compositionengine/RenderSurface.h>
+#include <compositionengine/UdfpsExtension.h>
 #include <compositionengine/impl/Output.h>
 #include <compositionengine/impl/OutputCompositionState.h>
 #include <compositionengine/impl/OutputLayer.h>
@@ -775,7 +776,9 @@ void Output::writeCompositionState(const compositionengine::CompositionRefreshAr
 
 compositionengine::OutputLayer* Output::findLayerRequestingBackgroundComposition() const {
     compositionengine::OutputLayer* layerRequestingBgComposition = nullptr;
-    for (auto* layer : getOutputLayersOrderedByZ()) {
+    for (size_t i = 0; i < getOutputLayerCount(); i++) {
+        compositionengine::OutputLayer* layer = getOutputLayerOrderedByZByIndex(i);
+        compositionengine::OutputLayer* nextLayer = getOutputLayerOrderedByZByIndex(i + 1);
         auto* compState = layer->getLayerFE().getCompositionState();
 
         // If any layer has a sideband stream, we will disable blurs. In that case, we don't
@@ -785,6 +788,14 @@ compositionengine::OutputLayer* Output::findLayerRequestingBackgroundComposition
         }
         if (compState->backgroundBlurRadius > 0 || compState->blurRegions.size() > 0) {
             layerRequestingBgComposition = layer;
+        }
+        // If the next layer is the Udfps touched layer, enable client composition for it
+        // because that somehow leads to the Udfps touched layer getting device composition
+        // consistently.
+        if ((nextLayer != nullptr && layerRequestingBgComposition == nullptr) &&
+                (strcmp(nextLayer->getLayerFE().getDebugName(), UDFPS_TOUCHED_LAYER_NAME) == 0)) {
+            layerRequestingBgComposition = layer;
+            break;
         }
     }
     return layerRequestingBgComposition;


### PR DESCRIPTION
The FOD layers should be always composed by the device to set the
custom zpos bits to the kernel. By default all layers are set to
device composition and the proprietary libsdmextension.so moves
some to client composition. Unfortunately that also affects the
Udfps touched layer. After this commit the layer below the Udfps
touched layer is forced to be client composition. For unknown
reasons libsdmextension will not change the Udfps touched layer
to client composition anymore.

tests:
- Run 'adb shell dumpsys SurfaceFlinger' and ensure that the Udfps
  touched layer is composed by the device
- Ensure that the Udfps touched layer correctly sets the zpos bits
  on the kernel while / after using WFD

Signed-off-by: daniml3 <danimoral1001@gmail.com>
Signed-off-by: Arian <arian.kulmer@web.de>
Signed-off-by: markkey014 <khevinrogacion@gmail.com>
Change-Id: I8aeb98d18557ad4e971eaba74700ceb3058273ab